### PR TITLE
Python 3.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ def main():
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
         ],
-        python_requires=">=3.7.0,<3.11.0",
+        python_requires=">=3.7.0",
     )
 
 


### PR DESCRIPTION
Portal is now running off 3.12...hopefully this doesn't really break anything we're using